### PR TITLE
Refactor/emergency stop controller

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+IndentWidth: 4
+AccessModifierOffset: -4
+ColumnLimit: 120

--- a/emergency_stop_controller/include/emergency_stop_controller/emergency_stop_controller.hpp
+++ b/emergency_stop_controller/include/emergency_stop_controller/emergency_stop_controller.hpp
@@ -26,7 +26,8 @@ private:
     void initValues(const InitParams& init_params);
     void printParam(const InitParams& init_params) const;
     void canFrameCallback(const can_msgs::msg::Frame::SharedPtr msg);
-    void publishTwistCallback();
+    void publishTwistCallback() const;
+    void publishStopTwist() const;
 
     rclcpp::TimerBase::SharedPtr publish_twist_timer_;
     rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr can_sub_;

--- a/emergency_stop_controller/src/emergency_stop_controller.cpp
+++ b/emergency_stop_controller/src/emergency_stop_controller.cpp
@@ -55,17 +55,24 @@ void EmergencyStopController::canFrameCallback(const can_msgs::msg::Frame::Share
     }
 
     if (msg->data[0] == 8 && msg->data[2] == 8) {
-        is_emergency_ = true;
-    } else {
+        if (!is_emergency_) {
+            is_emergency_ = true;
+            publishStopTwist();
+        }
+    } else if (is_emergency_) {
         is_emergency_ = false;
     }
 }
 
-void EmergencyStopController::publishTwistCallback() {
+void EmergencyStopController::publishTwistCallback() const {
     if (is_emergency_) {
-        twist_pub_->publish(stop_twist_);
-        RCLCPP_INFO_ONCE(this->get_logger(), "Publish Twist !");
+        publishStopTwist();
     }
+}
+
+void EmergencyStopController::publishStopTwist() const {
+    twist_pub_->publish(stop_twist_);
+    RCLCPP_INFO_ONCE(this->get_logger(), "Publish Twist !");
 }
 
 }  // namespace aiformula

--- a/emergency_stop_controller/src/emergency_stop_controller.cpp
+++ b/emergency_stop_controller/src/emergency_stop_controller.cpp
@@ -48,7 +48,8 @@ void EmergencyStopController::canFrameCallback(const can_msgs::msg::Frame::Share
     RCLCPP_INFO_ONCE(this->get_logger(), "Subscribe Can Frame !");
     if (msg->id != this->EMERGENCY_CAN_ID) return;
 
-    if (msg->dlc != 4) {
+    static constexpr uint8_t EMERGENCY_CAN_DLC = 4;
+    if (msg->dlc != EMERGENCY_CAN_DLC) {
         RCLCPP_WARN(this->get_logger(), "Invalid DLC: expected 4, got %d (id=0x%X)", msg->dlc, msg->id);
         return;
     }


### PR DESCRIPTION
## 概要
- 緊急停止ボタン押下時，即座に停止 Twist トピックをpublish するように修正（https://github.com/aiformula-support/aiformula/pull/9 の未修正分）
- cpp ファイルのフォーマッター用に `.clang-format` を追加
- サブモジュールの更新


## Check List
- [x] 必要な変更のpush漏れが無い (`git status` や VSCode 等で確認)
- [x] 不必要な変更のpushが無い (`git status` や VSCode 等で確認)
- [x] `build`, `install`, `log` を消した状態からビルドが通る
- [x] 一括起動スクリプト `all_nodes.launch.py` で，全てのノードが問題なく起動する
- [x] 緊急停止ボタン押下時，即座に停止 Twist トピックがpublish される
- [x] VS Code にてcppファイルをフォーマットできる


## 動作確認手順（レビュワー再現用）
- 一括起動スクリプトで実行
    ```sh
    ros2 launch sample_launchers all_nodes.launch.py
    ```

- `.vscode/settings.json` に下記を追加することで，cpp ファイル保存時に自動でフォーマットされる
    ```json
    "C_Cpp.intelliSenseEngine": "Tag Parser",
    "[cpp]": {
        "editor.defaultFormatter": "xaver.clang-format",
        "editor.formatOnSave": true,
        "diffEditor.ignoreTrimWhitespace": false,
    },
    ```

## エビデンスの提示
- 一括起動スクリプトで実行（`emergency_stop_controller` のみ起動）し，ros bag 再生．緊急停止が押されたら，Twist トピックが流れている

https://github.com/user-attachments/assets/74168c21-cc28-4c26-a026-64d538619189
